### PR TITLE
Added basic global command cooldown (in fractional seconds)

### DIFF
--- a/src/DevChatter.Bot.Core/Commands/CommandUsage.cs
+++ b/src/DevChatter.Bot.Core/Commands/CommandUsage.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace DevChatter.Bot.Core.Commands
+{
+    public class CommandUsage
+    {
+        public CommandUsage(string displayName, DateTimeOffset timeInvoked, bool wasUserWarned)
+        {
+            DisplayName = displayName;
+            TimeInvoked = timeInvoked;
+            WasUserWarned = wasUserWarned;
+        }
+
+        public string DisplayName { get; set; }
+        public DateTimeOffset TimeInvoked { get; set; }
+        public bool WasUserWarned { get; set; }
+    }
+}

--- a/src/DevChatter.Bot.Core/Commands/CommandUsageTracker.cs
+++ b/src/DevChatter.Bot.Core/Commands/CommandUsageTracker.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using DevChatter.Bot.Core.Extensions;
+using DevChatter.Bot.Core.Events;
+
+namespace DevChatter.Bot.Core.Commands
+{
+    public class CommandUsageTracker
+    {
+        private readonly CommandHandlerSettings _settings;
+
+        private readonly List<CommandUsage> _userCommandUsages = new List<CommandUsage>();
+
+        public CommandUsageTracker(CommandHandlerSettings settings)
+        {
+            _settings = settings;
+        }
+
+        public void PurgeExpiredUserCommandCooldowns(DateTimeOffset currentTime)
+        {
+            var expiredCooldowns = new List<CommandUsage>();
+
+            foreach (var cooldownPair in _userCommandUsages)
+            {
+                var elapsedTime = currentTime - cooldownPair.TimeInvoked;
+                if (elapsedTime.TotalSeconds >= _settings.GlobalCommandCooldown)
+                {
+                    expiredCooldowns.Add(cooldownPair);
+                }
+            }
+
+            foreach (var user in expiredCooldowns)
+            {
+                _userCommandUsages.Remove(user);
+            }
+        }
+
+        public CommandUsage GetByUserDisplayName(string userDisplayName)
+        {
+            return _userCommandUsages.SingleOrDefault(x => StringExtensions.EqualsIns(x.DisplayName, userDisplayName));
+        }
+
+        public void RecordUsage(CommandUsage commandUsage)
+        {
+            _userCommandUsages.Add(commandUsage);
+        }
+    }
+}

--- a/src/DevChatter.Bot.Core/Events/CommandHandlerSettings.cs
+++ b/src/DevChatter.Bot.Core/Events/CommandHandlerSettings.cs
@@ -1,0 +1,10 @@
+﻿namespace DevChatter.Bot.Core.Events
+{
+    public class CommandHandlerSettings
+    {
+        /// <summary>
+        /// Cooldown in seconds between commands
+        /// </summary>
+        public double GlobalCommandCooldown { get; set; }
+    }
+}

--- a/src/DevChatter.Bot.Core/Extensions/StringExtensions.cs
+++ b/src/DevChatter.Bot.Core/Extensions/StringExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 
@@ -17,6 +18,14 @@ namespace DevChatter.Bot.Core.Extensions
             MatchCollection matches = TokenFindingRegex.Matches(src);
             IEnumerable<Match> matchesEnumerable = matches.OfType<Match>();
             return matchesEnumerable.Select(m => m.Value);
+        }
+
+        /// <summary>
+        /// Case Insensitive Equality Comparison using StringComparison.InvariantCultureIgnoreCase
+        /// </summary>
+        public static bool EqualsIns(this string a, string b)
+        {
+            return a.Equals(b, StringComparison.InvariantCultureIgnoreCase);
         }
     }
 }

--- a/src/DevChatter.Bot/Program.cs
+++ b/src/DevChatter.Bot/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using DevChatter.Bot.Core;
+using DevChatter.Bot.Core.Events;
 using DevChatter.Bot.Infra.Twitch;
 using DevChatter.Bot.Startup;
 
@@ -11,9 +12,9 @@ namespace DevChatter.Bot
         {
             Console.WriteLine("Initializing the Bot...");
             
-            (string connectionString, TwitchClientSettings clientSettings) = SetUpConfig.InitializeConfiguration();
+            (string connectionString, TwitchClientSettings clientSettings, CommandHandlerSettings commandHandlerSettings) = SetUpConfig.InitializeConfiguration();
 
-            BotMain botMain = SetUpBot.NewBot(clientSettings, connectionString);
+            BotMain botMain = SetUpBot.NewBot(clientSettings, commandHandlerSettings, connectionString);
             WaitForCommands(botMain);
         }
 

--- a/src/DevChatter.Bot/Startup/SetUpBot.cs
+++ b/src/DevChatter.Bot/Startup/SetUpBot.cs
@@ -56,7 +56,8 @@ namespace DevChatter.Bot.Startup
             allCommands.Add(new HangmanCommand(hangmanGame));
             allCommands.Add(new RockPaperScissorsCommand(rockPaperScissorsGame));
 
-            var commandHandler = new CommandHandler(commandHandlerSettings, chatClients, allCommands);
+            var commandUsageTracker = new CommandUsageTracker(commandHandlerSettings);
+            var commandHandler = new CommandHandler(commandUsageTracker, chatClients, allCommands);
             var subscriberHandler = new SubscriberHandler(chatClients);
 
             var twitchSystem = new FollowableSystem(new[] { twitchChatClient }, twitchFollowerService);

--- a/src/DevChatter.Bot/Startup/SetUpBot.cs
+++ b/src/DevChatter.Bot/Startup/SetUpBot.cs
@@ -16,7 +16,7 @@ namespace DevChatter.Bot.Startup
 {
     public static class SetUpBot
     {
-        public static BotMain NewBot(TwitchClientSettings twitchSettings, string connectionString)
+        public static BotMain NewBot(TwitchClientSettings twitchSettings, CommandHandlerSettings commandHandlerSettings, string connectionString)
         {
             var twitchApi = new TwitchAPI(twitchSettings.TwitchClientId);
             var twitchChatClient = new TwitchChatClient(twitchSettings, twitchApi);
@@ -56,7 +56,7 @@ namespace DevChatter.Bot.Startup
             allCommands.Add(new HangmanCommand(hangmanGame));
             allCommands.Add(new RockPaperScissorsCommand(rockPaperScissorsGame));
 
-            var commandHandler = new CommandHandler(chatClients, allCommands);
+            var commandHandler = new CommandHandler(commandHandlerSettings, chatClients, allCommands);
             var subscriberHandler = new SubscriberHandler(chatClients);
 
             var twitchSystem = new FollowableSystem(new[] { twitchChatClient }, twitchFollowerService);

--- a/src/DevChatter.Bot/Startup/SetUpConfig.cs
+++ b/src/DevChatter.Bot/Startup/SetUpConfig.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using DevChatter.Bot.Core.Events;
 using DevChatter.Bot.Infra.Twitch;
 using Microsoft.Extensions.Configuration;
 
@@ -6,7 +7,7 @@ namespace DevChatter.Bot.Startup
 {
     public static class SetUpConfig
     {
-        public static (string, TwitchClientSettings) InitializeConfiguration()
+        public static (string, TwitchClientSettings, CommandHandlerSettings) InitializeConfiguration()
         {
             Console.WriteLine("Initializing configuration...");
 
@@ -17,7 +18,7 @@ namespace DevChatter.Bot.Startup
 
             IConfigurationRoot configuration = builder.Build();
 
-            return (configuration.GetConnectionString("DevChatterBotDb"), configuration.Get<TwitchClientSettings>());
+            return (configuration.GetConnectionString("DevChatterBotDb"), configuration.Get<TwitchClientSettings>(), configuration.Get<CommandHandlerSettings>());
         }
     }
 }

--- a/src/DevChatter.Bot/appsettings.json
+++ b/src/DevChatter.Bot/appsettings.json
@@ -4,6 +4,7 @@
   "TwitchOAuth": "secret",
   "TwitchChannel": "secret",
   "TwitchClientId": "secret",
+  "GlobalCommandCooldown":  "0.5", 
   "ConnectionStrings": {
     "DevChatterBotDb": "Server=(localdb)\\mssqllocaldb;Database=DevChatterBot;Trusted_Connection=True;MultipleActiveResultSets=true"
   }

--- a/src/DevChatter.Bot/appsettings.json
+++ b/src/DevChatter.Bot/appsettings.json
@@ -4,7 +4,7 @@
   "TwitchOAuth": "secret",
   "TwitchChannel": "secret",
   "TwitchClientId": "secret",
-  "GlobalCommandCooldown":  "0.5", 
+  "GlobalCommandCooldown":  "2.5", 
   "ConnectionStrings": {
     "DevChatterBotDb": "Server=(localdb)\\mssqllocaldb;Database=DevChatterBot;Trusted_Connection=True;MultipleActiveResultSets=true"
   }


### PR DESCRIPTION
Referencing Issue #32  

I have added a basic global cooldown implementation for the CommandHandler.

I was thinking that the global cooldown should really apply to each IChatClient independently. You probably wouldn't want someone using commands in Discord to affect someone using commands in Twitch.

In order to do that I could add a `Dictionary<IChatClient, DateTimeOffset>` to look up the last time a command was used from a particular chat client, but I was also considering maybe there should be an identifier for an IChatClient and it would be a `Dictionary<SomeIdentifierType, DateTimeOffset>` instead.

Let me know if you want me to change anything about this implementation.
