### PR TITLE
Added !cmd as default command #96

### DIFF
--- a/src/DevChatter.Bot.Core/Commands/CommandsCommand.cs
+++ b/src/DevChatter.Bot.Core/Commands/CommandsCommand.cs
@@ -11,7 +11,7 @@ namespace DevChatter.Bot.Core.Commands
         private readonly List<IBotCommand> _allCommands;
 
         public CommandsCommand(List<IBotCommand> allCommands)
-            : base(UserRole.Everyone, "commands")
+            : base(UserRole.Everyone, "commands", "cmd")
         {
             _allCommands = allCommands;
         }


### PR DESCRIPTION
Is there more to it?

I didn't see it fit to add it to the list of returned commands from the `CommandsCommand`, when it is more of an alternative to !commands (like !points is a not-listed alternative for !coins for the `CoinsCommand`).