### PR TITLE
Integrated autofac DI container

### DIFF
--- a/src/DevChatter.Bot.Core/Automation/AutomatedActionSystem.cs
+++ b/src/DevChatter.Bot.Core/Automation/AutomatedActionSystem.cs
@@ -3,11 +3,11 @@ using System.Linq;
 
 namespace DevChatter.Bot.Core.Automation
 {
-    public class AutomatedActionSystem
+    public class AutomatedActionSystem : IAutomatedActionSystem
     {
-        private readonly List<IIntervalAction> _actions;
+        private readonly IList<IIntervalAction> _actions;
 
-        public AutomatedActionSystem(List<IIntervalAction> actions)
+        public AutomatedActionSystem(IList<IIntervalAction> actions)
         {
             _actions = actions;
         }

--- a/src/DevChatter.Bot.Core/Automation/CurrencyUpdate.cs
+++ b/src/DevChatter.Bot.Core/Automation/CurrencyUpdate.cs
@@ -6,10 +6,10 @@ namespace DevChatter.Bot.Core.Automation
     public class CurrencyUpdate : IIntervalAction
     {
         private readonly int _intervalInMinutes;
-        private readonly CurrencyGenerator _currencyGenerator;
+        private readonly ICurrencyGenerator _currencyGenerator;
         private DateTime _nextRunTime;
 
-        public CurrencyUpdate(int intervalInMinutes, CurrencyGenerator currencyGenerator)
+        public CurrencyUpdate(int intervalInMinutes, ICurrencyGenerator currencyGenerator)
         {
             _intervalInMinutes = intervalInMinutes;
             _currencyGenerator = currencyGenerator;

--- a/src/DevChatter.Bot.Core/Automation/IAutomatedActionSystem.cs
+++ b/src/DevChatter.Bot.Core/Automation/IAutomatedActionSystem.cs
@@ -1,0 +1,9 @@
+﻿namespace DevChatter.Bot.Core.Automation
+{
+    public interface IAutomatedActionSystem
+    {
+        void AddAction(IIntervalAction actionToAdd);
+        void RemoveAction(IIntervalAction actionToRemove);
+        void RunNecessaryActions();
+    }
+}

--- a/src/DevChatter.Bot.Core/BotMain.cs
+++ b/src/DevChatter.Bot.Core/BotMain.cs
@@ -10,27 +10,26 @@ using DevChatter.Bot.Core.Systems.Streaming;
 
 namespace DevChatter.Bot.Core
 {
-    public class BotMain
+    public class BotMain : IBotMain
     {
-        private readonly List<IChatClient> _chatClients;
+        private readonly IList<IChatClient> _chatClients;
         private readonly IRepository _repository;
-        private readonly AutomatedMessagingSystem _autoMsgSystem = new AutomatedMessagingSystem();
-        private readonly CommandHandler _commandHandler;
+        private readonly IAutomatedMessagingSystem _autoMsgSystem = new AutomatedMessagingSystem();
+        private readonly ICommandHandler _commandHandler;
         private readonly SubscriberHandler _subscriberHandler;
-        private readonly FollowableSystem _followableSystem; // This will eventually be a list of these
-        private readonly AutomatedActionSystem _automatedActionSystem;
+        private readonly IFollowableSystem _followableSystem; // This will eventually be a list of these
+        private readonly IAutomatedActionSystem _automatedActionSystem;
         private CancellationTokenSource _stopRequestSource;
         private readonly int _refreshInterval = 1000;//the milliseconds the bot waits before checking for new messages
 
-        public BotMain(List<IChatClient> chatClients, IRepository repository, CommandHandler commandHandler,
-            SubscriberHandler subscriberHandler, FollowableSystem followableSystem, AutomatedActionSystem automatedActionSystem)
+        public BotMain(IList<IChatClient> chatClients, IRepository repository, IFollowableSystem followableSystem, IAutomatedActionSystem automatedActionSystem, ICommandHandler commandHandler, SubscriberHandler subscriberHandler)
         {
             _chatClients = chatClients;
             _repository = repository;
-            _commandHandler = commandHandler;
-            _subscriberHandler = subscriberHandler;
             _followableSystem = followableSystem;
             _automatedActionSystem = automatedActionSystem;
+            _commandHandler = commandHandler;
+            _subscriberHandler = subscriberHandler;
         }
 
         public void Run()

--- a/src/DevChatter.Bot.Core/ChatUserCollection.cs
+++ b/src/DevChatter.Bot.Core/ChatUserCollection.cs
@@ -7,7 +7,7 @@ using DevChatter.Bot.Core.Data.Specifications;
 
 namespace DevChatter.Bot.Core
 {
-    public class ChatUserCollection
+    public class ChatUserCollection : IChatUserCollection
     {
         private readonly IRepository _repository;
         private readonly object _userCreationLock = new object();

--- a/src/DevChatter.Bot.Core/Commands/AddCommandCommand.cs
+++ b/src/DevChatter.Bot.Core/Commands/AddCommandCommand.cs
@@ -12,15 +12,15 @@ namespace DevChatter.Bot.Core.Commands
     public class AddCommandCommand : BaseCommand
     {
         private readonly IRepository _repository;
-        private readonly List<IBotCommand> _allCommands;
 
-        public AddCommandCommand(IRepository repository, List<IBotCommand> allCommands)
+        public AddCommandCommand(IRepository repository)
             : base(UserRole.Mod, "AddCommand", "CommandAdd")
         {
             _repository = repository;
-            _allCommands = allCommands;
             HelpText = "To add a command to the bot use \"!AddCommand Command Text PermissionLevel\" Example: !AddCommand Twitter \"https://twitter.com/DevChatter_\" Everyone";
         }
+
+        public IList<IBotCommand> AllCommands { get; set; }
 
         public override void Process(IChatClient chatClient, CommandReceivedEventArgs eventArgs)
         {
@@ -45,7 +45,7 @@ namespace DevChatter.Bot.Core.Commands
                 chatClient.SendMessage($"Adding a !{command.CommandText} command for {command.RoleRequired}. It will respond with {command.StaticResponse}.");
 
                 _repository.Create(command);
-                _allCommands.Add(command);
+                AllCommands.Add(command);
             }
             catch (Exception e)
             {

--- a/src/DevChatter.Bot.Core/Commands/BonusCommand.cs
+++ b/src/DevChatter.Bot.Core/Commands/BonusCommand.cs
@@ -9,9 +9,9 @@ namespace DevChatter.Bot.Core.Commands
 {
     public class BonusCommand : BaseCommand
     {
-        private readonly CurrencyGenerator _currencyGenerator;
+        private readonly ICurrencyGenerator _currencyGenerator;
 
-        public BonusCommand(CurrencyGenerator currencyGenerator)
+        public BonusCommand(ICurrencyGenerator currencyGenerator)
             : base(UserRole.Mod, "Bonus")
         {
             _currencyGenerator = currencyGenerator;

--- a/src/DevChatter.Bot.Core/Commands/CommandList.cs
+++ b/src/DevChatter.Bot.Core/Commands/CommandList.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace DevChatter.Bot.Core.Commands
+{
+    public class CommandList : IList<IBotCommand>
+    {
+        private readonly IList<IBotCommand> _list;
+
+        public CommandList(IList<IBotCommand> list)
+        {
+            _list = list ?? throw new ArgumentNullException(nameof(list));
+        }
+
+        public IEnumerator<IBotCommand> GetEnumerator()
+        {
+            return _list.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return ((IEnumerable) _list).GetEnumerator();
+        }
+
+        public void Add(IBotCommand item)
+        {
+            _list.Add(item);
+        }
+
+        public void Clear()
+        {
+            _list.Clear();
+        }
+
+        public bool Contains(IBotCommand item)
+        {
+            return _list.Contains(item);
+        }
+
+        public void CopyTo(IBotCommand[] array, int arrayIndex)
+        {
+            _list.CopyTo(array, arrayIndex);
+        }
+
+        public bool Remove(IBotCommand item)
+        {
+            return _list.Remove(item);
+        }
+
+        public int Count => _list.Count;
+
+        public bool IsReadOnly => _list.IsReadOnly;
+
+        public int IndexOf(IBotCommand item)
+        {
+            return _list.IndexOf(item);
+        }
+
+        public void Insert(int index, IBotCommand item)
+        {
+            _list.Insert(index, item);
+        }
+
+        public void RemoveAt(int index)
+        {
+            _list.RemoveAt(index);
+        }
+
+        public IBotCommand this[int index]
+        {
+            get => _list[index];
+            set => _list[index] = value;
+        }
+    }
+}

--- a/src/DevChatter.Bot.Core/Commands/CommandUsageTracker.cs
+++ b/src/DevChatter.Bot.Core/Commands/CommandUsageTracker.cs
@@ -6,11 +6,11 @@ using DevChatter.Bot.Core.Events;
 
 namespace DevChatter.Bot.Core.Commands
 {
-    public class CommandUsageTracker
+    public class CommandUsageTracker : ICommandUsageTracker
     {
         private readonly CommandHandlerSettings _settings;
 
-        private readonly List<CommandUsage> _userCommandUsages = new List<CommandUsage>();
+        private readonly IList<CommandUsage> _userCommandUsages = new List<CommandUsage>();
 
         public CommandUsageTracker(CommandHandlerSettings settings)
         {
@@ -38,7 +38,7 @@ namespace DevChatter.Bot.Core.Commands
 
         public CommandUsage GetByUserDisplayName(string userDisplayName)
         {
-            return _userCommandUsages.SingleOrDefault(x => StringExtensions.EqualsIns(x.DisplayName, userDisplayName));
+            return _userCommandUsages.SingleOrDefault(x => x.DisplayName.EqualsIns(userDisplayName));
         }
 
         public void RecordUsage(CommandUsage commandUsage)

--- a/src/DevChatter.Bot.Core/Commands/CommandsCommand.cs
+++ b/src/DevChatter.Bot.Core/Commands/CommandsCommand.cs
@@ -8,17 +8,16 @@ namespace DevChatter.Bot.Core.Commands
 {
     public class CommandsCommand : BaseCommand
     {
-        private readonly List<IBotCommand> _allCommands;
-
-        public CommandsCommand(List<IBotCommand> allCommands)
+        public CommandsCommand()
             : base(UserRole.Everyone, "commands", "cmd")
         {
-            _allCommands = allCommands;
         }
+
+        public IEnumerable<IBotCommand> AllCommands { get; set; }
 
         public override void Process(IChatClient chatClient, CommandReceivedEventArgs eventArgs)
         {
-            var listOfCommands = _allCommands.Where(x => eventArgs.ChatUser.CanUserRunCommand(x)).Select(x => $"!{x.PrimaryCommandText}").ToList();
+            var listOfCommands = AllCommands.Where(x => eventArgs.ChatUser.CanUserRunCommand(x)).Select(x => $"!{x.PrimaryCommandText}").ToList();
 
             string stringOfCommands = string.Join(", ", listOfCommands);
             chatClient.SendMessage($"These are the commands that {eventArgs.ChatUser.DisplayName} is allowed to run: ({stringOfCommands})");

--- a/src/DevChatter.Bot.Core/Commands/GiveCommand.cs
+++ b/src/DevChatter.Bot.Core/Commands/GiveCommand.cs
@@ -8,9 +8,9 @@ namespace DevChatter.Bot.Core.Commands
 {
     public class GiveCommand : BaseCommand
     {
-        private readonly ChatUserCollection _chatUserCollection;
+        private readonly IChatUserCollection _chatUserCollection;
 
-        public GiveCommand(ChatUserCollection chatUserCollection)
+        public GiveCommand(IChatUserCollection chatUserCollection)
             : base(UserRole.Everyone, "Give")
         {
             _chatUserCollection = chatUserCollection;

--- a/src/DevChatter.Bot.Core/Commands/HelpCommand.cs
+++ b/src/DevChatter.Bot.Core/Commands/HelpCommand.cs
@@ -9,14 +9,13 @@ namespace DevChatter.Bot.Core.Commands
 {
     public class HelpCommand : BaseCommand
     {
-        private readonly List<IBotCommand> _allCommands;
-
-        public HelpCommand(List<IBotCommand> allCommands)
+        public HelpCommand()
             : base(UserRole.Everyone, "Help")
         {
-            _allCommands = allCommands;
             HelpText = "I think you figured this out already...";
         }
+
+        public IEnumerable<IBotCommand> AllCommands { get; set; }
 
         public override void Process(IChatClient chatClient, CommandReceivedEventArgs eventArgs)
         {
@@ -39,7 +38,7 @@ namespace DevChatter.Bot.Core.Commands
                 chatClient.SendMessage("Please be sure to drink your ovaltine.");
             }
 
-            IBotCommand requestedCommand = _allCommands.SingleOrDefault(x => x.ShouldExecute(argOne));
+            IBotCommand requestedCommand = AllCommands.SingleOrDefault(x => x.ShouldExecute(argOne));
 
             if (requestedCommand != null)
             {
@@ -49,7 +48,7 @@ namespace DevChatter.Bot.Core.Commands
 
         private void ShowAvailableCommands(IChatClient chatClient, ChatUser chatUser)
         {
-            var commands = _allCommands.Where(chatUser.CanUserRunCommand).Select(x => $"!{x.PrimaryCommandText}");
+            var commands = AllCommands.Where(chatUser.CanUserRunCommand).Select(x => $"!{x.PrimaryCommandText}");
             string stringOfCommands = string.Join(", ", commands);
 
             string message = $"These are the commands that {chatUser.DisplayName} is allowed to run: ({stringOfCommands})";

--- a/src/DevChatter.Bot.Core/Commands/ICommandUsageTracker.cs
+++ b/src/DevChatter.Bot.Core/Commands/ICommandUsageTracker.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace DevChatter.Bot.Core.Commands
+{
+    public interface ICommandUsageTracker
+    {
+        CommandUsage GetByUserDisplayName(string userDisplayName);
+        void PurgeExpiredUserCommandCooldowns(DateTimeOffset currentTime);
+        void RecordUsage(CommandUsage commandUsage);
+    }
+}

--- a/src/DevChatter.Bot.Core/Commands/RemoveCommandCommand.cs
+++ b/src/DevChatter.Bot.Core/Commands/RemoveCommandCommand.cs
@@ -12,14 +12,14 @@ namespace DevChatter.Bot.Core.Commands
     public class RemoveCommandCommand : BaseCommand
     {
         private readonly IRepository _repository;
-        private readonly List<IBotCommand> _allCommands;
 
-        public RemoveCommandCommand(IRepository repository, List<IBotCommand> allCommands)
+        public RemoveCommandCommand(IRepository repository)
             : base(UserRole.Mod, "RemoveCommand", "CommandRemove")
         {
             _repository = repository;
-            _allCommands = allCommands;
         }
+
+        public IList<IBotCommand> AllCommands { get; set; }
 
         public override void Process(IChatClient chatClient, CommandReceivedEventArgs eventArgs)
         {
@@ -39,10 +39,10 @@ namespace DevChatter.Bot.Core.Commands
                 chatClient.SendMessage($"Removing the !{commandText} command.");
 
                 _repository.Remove(command);
-                IBotCommand botCommand = _allCommands.SingleOrDefault(x => x.ShouldExecute(commandText));
+                IBotCommand botCommand = AllCommands.SingleOrDefault(x => x.ShouldExecute(commandText));
                 if (botCommand != null)
                 {
-                    _allCommands.Remove(botCommand);
+                    AllCommands.Remove(botCommand);
                 }
             }
             catch (Exception e)

--- a/src/DevChatter.Bot.Core/Commands/ShoutOutCommand.cs
+++ b/src/DevChatter.Bot.Core/Commands/ShoutOutCommand.cs
@@ -28,7 +28,7 @@ namespace DevChatter.Bot.Core.Commands
 
         private string GetRandomFollowedStream()
         {
-            List<string> usersWeFollow = _followerService.GetUsersWeFollow();
+            IList<string> usersWeFollow = _followerService.GetUsersWeFollow();
             int randomIndex = MyRandom.RandomNumber(0, usersWeFollow.Count);
             return usersWeFollow[randomIndex];
         }

--- a/src/DevChatter.Bot.Core/Commands/UptimeCommand.cs
+++ b/src/DevChatter.Bot.Core/Commands/UptimeCommand.cs
@@ -8,9 +8,9 @@ namespace DevChatter.Bot.Core.Commands
 {
     public class UptimeCommand : BaseCommand
     {
-        private readonly StreamingPlatform _streamingPlatform;
+        private readonly IStreamingPlatform _streamingPlatform;
 
-        public UptimeCommand(StreamingPlatform streamingPlatform)
+        public UptimeCommand(IStreamingPlatform streamingPlatform)
             : base(UserRole.Everyone, "Uptime")
         {
             _streamingPlatform = streamingPlatform;

--- a/src/DevChatter.Bot.Core/Events/CommandHandler.cs
+++ b/src/DevChatter.Bot.Core/Events/CommandHandler.cs
@@ -6,13 +6,13 @@ using DevChatter.Bot.Core.Systems.Chat;
 
 namespace DevChatter.Bot.Core.Events
 {
-    public class CommandHandler
+    public class CommandHandler : ICommandHandler
     {
-        private readonly CommandUsageTracker _usageTracker;
-        private readonly List<IBotCommand> _commandMessages;
+        private readonly ICommandUsageTracker _usageTracker;
+        private readonly IList<IBotCommand> _commandMessages;
 
-        public CommandHandler(CommandUsageTracker usageTracker, List<IChatClient> chatClients,
-            List<IBotCommand> commandMessages)
+        public CommandHandler(ICommandUsageTracker usageTracker, IEnumerable<IChatClient> chatClients,
+            CommandList commandMessages)
         {
             _usageTracker = usageTracker;
             _commandMessages = commandMessages;

--- a/src/DevChatter.Bot.Core/Events/CommandReceivedEventArgs.cs
+++ b/src/DevChatter.Bot.Core/Events/CommandReceivedEventArgs.cs
@@ -6,7 +6,7 @@ namespace DevChatter.Bot.Core.Events
     public class CommandReceivedEventArgs
     {
         public string CommandWord { get; set; }
-        public List<string> Arguments { get; set; } = new List<string>();
+        public IList<string> Arguments { get; set; } = new List<string>();
         public ChatUser ChatUser { get; set; } = new ChatUser();
     }
 }

--- a/src/DevChatter.Bot.Core/Events/CurrencyGenerator.cs
+++ b/src/DevChatter.Bot.Core/Events/CurrencyGenerator.cs
@@ -5,11 +5,11 @@ using DevChatter.Bot.Core.Systems.Chat;
 
 namespace DevChatter.Bot.Core.Events
 {
-    public class CurrencyGenerator
+    public class CurrencyGenerator : ICurrencyGenerator
     {
-        private readonly ChatUserCollection _chatUserCollection;
+        private readonly IChatUserCollection _chatUserCollection;
 
-        public CurrencyGenerator(List<IChatClient> chatClients, ChatUserCollection chatUserCollection)
+        public CurrencyGenerator(IList<IChatClient> chatClients, IChatUserCollection chatUserCollection)
         {
             _chatUserCollection = chatUserCollection;
             foreach (IChatClient chatClient in chatClients)
@@ -22,7 +22,7 @@ namespace DevChatter.Bot.Core.Events
 
         private void AddCurrentChatters(IChatClient chatClient)
         {
-            List<ChatUser> allChatters = chatClient.GetAllChatters();
+            IList<ChatUser> allChatters = chatClient.GetAllChatters();
             foreach (ChatUser chatter in allChatters)
             {
                 WatchUserIfNeeded(chatter.DisplayName, chatter);

--- a/src/DevChatter.Bot.Core/Events/ICommandHandler.cs
+++ b/src/DevChatter.Bot.Core/Events/ICommandHandler.cs
@@ -1,0 +1,7 @@
+﻿namespace DevChatter.Bot.Core.Events
+{
+    public interface ICommandHandler
+    {
+        void CommandReceivedHandler(object sender, CommandReceivedEventArgs e);
+    }
+}

--- a/src/DevChatter.Bot.Core/Events/ICurrencyGenerator.cs
+++ b/src/DevChatter.Bot.Core/Events/ICurrencyGenerator.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace DevChatter.Bot.Core.Events
+{
+    public interface ICurrencyGenerator
+    {
+        void AddCurrencyTo(List<string> listOfNames, int tokensToAdd);
+        bool RemoveCurrencyFrom(string userName, int tokensToRemove);
+        void UpdateCurrency();
+    }
+}

--- a/src/DevChatter.Bot.Core/Events/NewFollowersEventArgs.cs
+++ b/src/DevChatter.Bot.Core/Events/NewFollowersEventArgs.cs
@@ -4,6 +4,6 @@ namespace DevChatter.Bot.Core.Events
 {
     public class NewFollowersEventArgs
     {
-        public List<string> FollowerNames { get; } = new List<string>();
+        public IList<string> FollowerNames { get; } = new List<string>();
     }
 }

--- a/src/DevChatter.Bot.Core/Events/SubscriberHandler.cs
+++ b/src/DevChatter.Bot.Core/Events/SubscriberHandler.cs
@@ -5,7 +5,7 @@ namespace DevChatter.Bot.Core.Events
 {
     public class SubscriberHandler
     {
-        public SubscriberHandler(List<IChatClient> chatClients)
+        public SubscriberHandler(IList<IChatClient> chatClients)
         {
             foreach (IChatClient chatClient in chatClients)
             {

--- a/src/DevChatter.Bot.Core/Extensions/ListOfStringExtensions.cs
+++ b/src/DevChatter.Bot.Core/Extensions/ListOfStringExtensions.cs
@@ -7,7 +7,7 @@ namespace DevChatter.Bot.Core.Extensions
 {
     public static class ListOfStringExtensions
     {
-        public static SimpleCommand ToSimpleCommand(this List<string> arguments)
+        public static SimpleCommand ToSimpleCommand(this IList<string> arguments)
         {
             if (arguments.Count >= 3 && Enum.TryParse(arguments[2], out UserRole role))
             {

--- a/src/DevChatter.Bot.Core/Games/Hangman/HangmanGame.cs
+++ b/src/DevChatter.Bot.Core/Games/Hangman/HangmanGame.cs
@@ -17,10 +17,10 @@ namespace DevChatter.Bot.Core.Games.Hangman
 
         private readonly List<HangmanGuess> _guessedLetters = new List<HangmanGuess>();
 
-        private readonly List<string> _wordList;
+        private readonly IWordListProvider _wordList;
 
         private string _password;
-        public string Password => _password ?? (_password = _wordList.OrderBy(x => Guid.NewGuid()).FirstOrDefault());
+        public string Password => _password ?? (_password = _wordList.Words.OrderBy(x => Guid.NewGuid()).FirstOrDefault());
 
         public string MaskedPassword
         {
@@ -37,13 +37,13 @@ namespace DevChatter.Bot.Core.Games.Hangman
             }
         }
 
-        private readonly CurrencyGenerator _currencyGenerator;
-        private readonly AutomatedActionSystem _automatedActionSystem;
+        private readonly ICurrencyGenerator _currencyGenerator;
+        private readonly IAutomatedActionSystem _automatedActionSystem;
 
         private bool _isRunningGame;
 
-        public HangmanGame(CurrencyGenerator currencyGenerator, AutomatedActionSystem automatedActionSystem, 
-            List<string> wordList)
+        public HangmanGame(ICurrencyGenerator currencyGenerator, IAutomatedActionSystem automatedActionSystem, 
+            IWordListProvider wordList)
         {
             _currencyGenerator = currencyGenerator;
             _automatedActionSystem = automatedActionSystem;
@@ -167,16 +167,5 @@ namespace DevChatter.Bot.Core.Games.Hangman
         {
             chatClient.SendMessage($"There's no {nameof(HangmanGame)} running, {chatUser.DisplayName}.");
         }
-    }
-
-    public class HangmanGuess
-    {
-        public HangmanGuess(string letter, ChatUser guesser)
-        {
-            Letter = letter;
-            Guesser = guesser;
-        }
-        public string Letter { get; }
-        public ChatUser Guesser { get; }
     }
 }

--- a/src/DevChatter.Bot.Core/Games/Hangman/HangmanGuess.cs
+++ b/src/DevChatter.Bot.Core/Games/Hangman/HangmanGuess.cs
@@ -1,0 +1,15 @@
+﻿using DevChatter.Bot.Core.Data.Model;
+
+namespace DevChatter.Bot.Core.Games.Hangman
+{
+    public class HangmanGuess
+    {
+        public HangmanGuess(string letter, ChatUser guesser)
+        {
+            Letter = letter;
+            Guesser = guesser;
+        }
+        public string Letter { get; }
+        public ChatUser Guesser { get; }
+    }
+}

--- a/src/DevChatter.Bot.Core/Games/Hangman/HardcodedWordListProvider.cs
+++ b/src/DevChatter.Bot.Core/Games/Hangman/HardcodedWordListProvider.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+
+namespace DevChatter.Bot.Core.Games.Hangman
+{
+    public class HardcodedWordListProvider : IWordListProvider
+    {
+        public IList<string> Words { get; } = new[]
+        {
+            "apple", "banana", "orange", "mango", "watermellon", "grapes", "pizza", "pasta",
+            "pepperoni", "cheese", "mushroom", "csharp", "javascript", "cplusplus",
+            "nullreferenceexception", "parameter", "argument"
+        };
+    }
+}

--- a/src/DevChatter.Bot.Core/Games/Hangman/IWordListProvider.cs
+++ b/src/DevChatter.Bot.Core/Games/Hangman/IWordListProvider.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace DevChatter.Bot.Core.Games.Hangman
+{
+    public interface IWordListProvider
+    {
+        IList<string> Words { get; }
+    }
+}

--- a/src/DevChatter.Bot.Core/Games/RockPaperScissors/RockPaperScissors.cs
+++ b/src/DevChatter.Bot.Core/Games/RockPaperScissors/RockPaperScissors.cs
@@ -24,7 +24,7 @@ namespace DevChatter.Bot.Core.Games.RockPaperScissors
             return GetById((Id + 1) % 3);
         }
 
-        public static List<RockPaperScissors> All { get; } = new List<RockPaperScissors> {Rock, Paper, Scissors};
+        public static IList<RockPaperScissors> All { get; } = new List<RockPaperScissors> {Rock, Paper, Scissors};
 
         public static RockPaperScissors GetById(int id)
         {

--- a/src/DevChatter.Bot.Core/Games/RockPaperScissors/RockPaperScissorsGame.cs
+++ b/src/DevChatter.Bot.Core/Games/RockPaperScissors/RockPaperScissorsGame.cs
@@ -11,15 +11,15 @@ namespace DevChatter.Bot.Core.Games.RockPaperScissors
         private const int SECONDS_TO_JOIN_GAME = 120;
         private const int TOKENS_FOR_WINNING = 100;
         private const int TOKENS_REQUIRED_TO_PLAY = 30;
-        private readonly CurrencyGenerator _currencyGenerator;
-        private readonly AutomatedActionSystem _automatedActionSystem;
-        private readonly Dictionary<string, RockPaperScissors> _competitors = new Dictionary<string, RockPaperScissors>();
+        private readonly ICurrencyGenerator _currencyGenerator;
+        private readonly IAutomatedActionSystem _automatedActionSystem;
+        private readonly IDictionary<string, RockPaperScissors> _competitors = new Dictionary<string, RockPaperScissors>();
         private readonly object _gameStartLock = new object();
         private bool _isRunningGame;
         private RockPaperScissorsEndGame _rockPaperScissorsEndGame;
-        private DelayedMessageAction _joinGameWarningMessage;
+        private IIntervalAction _joinGameWarningMessage;
 
-        public RockPaperScissorsGame(CurrencyGenerator currencyGenerator, AutomatedActionSystem automatedActionSystem)
+        public RockPaperScissorsGame(ICurrencyGenerator currencyGenerator, IAutomatedActionSystem automatedActionSystem)
         {
             _currencyGenerator = currencyGenerator;
             _automatedActionSystem = automatedActionSystem;

--- a/src/DevChatter.Bot.Core/IBotMain.cs
+++ b/src/DevChatter.Bot.Core/IBotMain.cs
@@ -1,0 +1,8 @@
+﻿namespace DevChatter.Bot.Core
+{
+    public interface IBotMain
+    {
+        void Run();
+        void Stop();
+    }
+}

--- a/src/DevChatter.Bot.Core/IChatUserCollection.cs
+++ b/src/DevChatter.Bot.Core/IChatUserCollection.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using DevChatter.Bot.Core.Data.Model;
+
+namespace DevChatter.Bot.Core
+{
+    public interface IChatUserCollection
+    {
+        ChatUser GetOrCreateChatUser(string displayName, ChatUser chatUser = null);
+        bool NeedToWatchUser(string displayName);
+        void StopWatching(string displayName);
+        bool TryGiveCoins(string coinGiver, string coinReceiver, int coinsToGive);
+        void UpdateEachChatter(Action<ChatUser> updateToApply);
+        void UpdateSpecficChatters(Action<ChatUser> updateToApply, Func<ChatUser, bool> filter);
+        bool UserExists(string username);
+        bool UserHasAtLeast(string username, int tokensToRemove);
+        void WatchUser(ChatUser userFromDb);
+    }
+}

--- a/src/DevChatter.Bot.Core/Messaging/AutomatedMessagingSystem.cs
+++ b/src/DevChatter.Bot.Core/Messaging/AutomatedMessagingSystem.cs
@@ -4,10 +4,10 @@ using System.Linq;
 
 namespace DevChatter.Bot.Core.Messaging
 {
-    public class AutomatedMessagingSystem
+    public class AutomatedMessagingSystem : IAutomatedMessagingSystem
     {
-        public List<IAutomatedMessage> ManagedMessages { get; set; } = new List<IAutomatedMessage>(); // TODO: Lock down access to this
-        public List<string> QueuedMessages { get; set; } = new List<string>(); // TODO: Lock down access to this
+        public IList<IAutomatedMessage> ManagedMessages { get; set; } = new List<IAutomatedMessage>(); // TODO: Lock down access to this
+        public IList<string> QueuedMessages { get; set; } = new List<string>(); // TODO: Lock down access to this
 
         public void Publish(IAutomatedMessage automatedMessage)
         {
@@ -18,7 +18,7 @@ namespace DevChatter.Bot.Core.Messaging
         {
             var messagesToQueue = ManagedMessages.Where(m => m.IsTimeToDisplay()).Select(m => m.GetMessageInstance());
 
-            QueuedMessages.AddRange(messagesToQueue);
+            QueuedMessages = QueuedMessages.Concat(messagesToQueue).ToList();
         }
 
         public bool DequeueMessage(out string message)

--- a/src/DevChatter.Bot.Core/Messaging/IAutomatedMessagingSystem.cs
+++ b/src/DevChatter.Bot.Core/Messaging/IAutomatedMessagingSystem.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+
+namespace DevChatter.Bot.Core.Messaging
+{
+    public interface IAutomatedMessagingSystem
+    {
+        IList<IAutomatedMessage> ManagedMessages { get; set; }
+        IList<string> QueuedMessages { get; set; }
+
+        void CheckMessages();
+        bool DequeueMessage(out string message);
+        void Publish(IAutomatedMessage automatedMessage);
+    }
+}

--- a/src/DevChatter.Bot.Core/Systems/Chat/IChatClient.cs
+++ b/src/DevChatter.Bot.Core/Systems/Chat/IChatClient.cs
@@ -14,7 +14,7 @@ namespace DevChatter.Bot.Core.Systems.Chat
 
         void SendMessage(string message);
 
-        List<ChatUser> GetAllChatters();
+        IList<ChatUser> GetAllChatters();
 
         event EventHandler<CommandReceivedEventArgs> OnCommandReceived;
 

--- a/src/DevChatter.Bot.Core/Systems/Streaming/FollowableSystem.cs
+++ b/src/DevChatter.Bot.Core/Systems/Streaming/FollowableSystem.cs
@@ -4,7 +4,7 @@ using DevChatter.Bot.Core.Systems.Chat;
 
 namespace DevChatter.Bot.Core.Systems.Streaming
 {
-    public class FollowableSystem
+    public class FollowableSystem : IFollowableSystem
     {
         private readonly IList<IChatClient> _chatClients;
         private readonly IFollowerService _followerService;

--- a/src/DevChatter.Bot.Core/Systems/Streaming/IFollowableSystem.cs
+++ b/src/DevChatter.Bot.Core/Systems/Streaming/IFollowableSystem.cs
@@ -1,0 +1,8 @@
+﻿namespace DevChatter.Bot.Core.Systems.Streaming
+{
+    public interface IFollowableSystem
+    {
+        void HandleFollowerNotifications();
+        void StopHandlingNotifications();
+    }
+}

--- a/src/DevChatter.Bot.Core/Systems/Streaming/IFollowerService.cs
+++ b/src/DevChatter.Bot.Core/Systems/Streaming/IFollowerService.cs
@@ -7,6 +7,6 @@ namespace DevChatter.Bot.Core.Systems.Streaming
     public interface IFollowerService
     {
         event EventHandler<NewFollowersEventArgs> OnNewFollower;
-        List<string> GetUsersWeFollow();
+        IList<string> GetUsersWeFollow();
     }
 }

--- a/src/DevChatter.Bot.Core/Systems/Streaming/IStreamingPlatform.cs
+++ b/src/DevChatter.Bot.Core/Systems/Streaming/IStreamingPlatform.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace DevChatter.Bot.Core.Systems.Streaming
+{
+    public interface IStreamingPlatform
+    {
+        Task<TimeSpan?> GetUptimeAsync();
+    }
+}

--- a/src/DevChatter.Bot.Core/Systems/Streaming/StreamingPlatform.cs
+++ b/src/DevChatter.Bot.Core/Systems/Streaming/StreamingPlatform.cs
@@ -4,7 +4,7 @@ using DevChatter.Bot.Core.Systems.Chat;
 
 namespace DevChatter.Bot.Core.Systems.Streaming
 {
-    public class StreamingPlatform
+    public class StreamingPlatform : IStreamingPlatform
     {
         private readonly IChatClient _chatClient;
         private readonly IFollowerService _followerService;

--- a/src/DevChatter.Bot.Infra.Twitch/Events/TwitchFollowerService.cs
+++ b/src/DevChatter.Bot.Infra.Twitch/Events/TwitchFollowerService.cs
@@ -13,12 +13,12 @@ namespace DevChatter.Bot.Infra.Twitch.Events
 {
     public class TwitchFollowerService : IFollowerService
     {
-        private readonly TwitchAPI _twitchApi;
+        private readonly ITwitchAPI _twitchApi;
         private readonly TwitchClientSettings _settings;
         private readonly FollowerService _followerService;
 
         private UserFollow[] _userFollows;
-        private UserFollow[] UserFollows {
+        private IEnumerable<UserFollow> UserFollows {
             get
             {
                 return _userFollows ?? (_userFollows =
@@ -26,7 +26,7 @@ namespace DevChatter.Bot.Infra.Twitch.Events
             }
         }
 
-        public TwitchFollowerService(TwitchAPI twitchApi, TwitchClientSettings settings)
+        public TwitchFollowerService(ITwitchAPI twitchApi, TwitchClientSettings settings)
         {
             _twitchApi = twitchApi;
 
@@ -46,7 +46,7 @@ namespace DevChatter.Bot.Infra.Twitch.Events
             OnNewFollower?.Invoke(sender, eventArgs.ToNewFollowerEventArgs());
         }
 
-        public List<string> GetUsersWeFollow()
+        public IList<string> GetUsersWeFollow()
         {
             return UserFollows.Select(uf => uf.Channel.Name).ToList();
         }

--- a/src/DevChatter.Bot.Infra.Twitch/Extensions/EventArgsExtensions.cs
+++ b/src/DevChatter.Bot.Infra.Twitch/Extensions/EventArgsExtensions.cs
@@ -64,7 +64,10 @@ namespace DevChatter.Bot.Infra.Twitch.Extensions
         {
             var eventArgs = new NewFollowersEventArgs();
 
-            eventArgs.FollowerNames.AddRange(src.NewFollowers.Select(x => x.User.DisplayName));
+            foreach (var followerName in src.NewFollowers.Select(x => x.User.DisplayName))
+            {
+                eventArgs.FollowerNames.Add(followerName);
+            }
 
             return eventArgs;
         }

--- a/src/DevChatter.Bot.Infra.Twitch/TwitchChatClient.cs
+++ b/src/DevChatter.Bot.Infra.Twitch/TwitchChatClient.cs
@@ -15,13 +15,13 @@ namespace DevChatter.Bot.Infra.Twitch
     public class TwitchChatClient : IChatClient
     {
         private readonly TwitchClientSettings _settings;
-        private readonly TwitchAPI _twitchApi;
-        private readonly TwitchClient _twitchClient;
+        private readonly ITwitchAPI _twitchApi;
+        private readonly ITwitchClient _twitchClient;
         private TaskCompletionSource<bool> _connectionCompletionTask = new TaskCompletionSource<bool>();
         private TaskCompletionSource<bool> _disconnectionCompletionTask = new TaskCompletionSource<bool>();
         private bool _isReady = false;
 
-        public TwitchChatClient(TwitchClientSettings settings, TwitchAPI twitchApi)
+        public TwitchChatClient(TwitchClientSettings settings, ITwitchAPI twitchApi)
         {
             _settings = settings;
             _twitchApi = twitchApi;
@@ -97,7 +97,7 @@ namespace DevChatter.Bot.Infra.Twitch
             }
         }
 
-        public List<ChatUser> GetAllChatters()
+        public IList<ChatUser> GetAllChatters()
         {
             var chatters = _twitchApi.Undocumented.GetChattersAsync(_settings.TwitchChannel).Result;
             var chatUsers = chatters.Select(x => x.ToChatUser()).ToList();

--- a/src/DevChatter.Bot/ConsoleChatClient.cs
+++ b/src/DevChatter.Bot/ConsoleChatClient.cs
@@ -24,7 +24,7 @@ namespace DevChatter.Bot
             Console.WriteLine(message);
         }
 
-        public List<ChatUser> GetAllChatters()
+        public IList<ChatUser> GetAllChatters()
         {
             return new List<ChatUser>();
         }

--- a/src/DevChatter.Bot/DevChatter.Bot.csproj
+++ b/src/DevChatter.Bot/DevChatter.Bot.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Autofac" Version="4.6.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.0.2" />

--- a/src/DevChatter.Bot/Program.cs
+++ b/src/DevChatter.Bot/Program.cs
@@ -1,6 +1,9 @@
 ﻿using System;
+using Autofac;
 using DevChatter.Bot.Core;
+using DevChatter.Bot.Core.Events;
 using DevChatter.Bot.Startup;
+using Microsoft.EntityFrameworkCore.Migrations.Operations;
 
 namespace DevChatter.Bot
 {
@@ -11,49 +14,75 @@ namespace DevChatter.Bot
             Console.WriteLine("Initializing the Bot...");
 
             var botConfiguration = SetUpConfig.InitializeConfiguration();
-
-            BotMain botMain = SetUpBot.NewBot(botConfiguration);
-            WaitForCommands(botMain);
+            var container = SetUpBot.NewBotDepedencyContainer(botConfiguration);
+            WaitForCommands(container);
         }
 
-        private static void WaitForCommands(BotMain botMain)
+        private static void WaitForCommands(IContainer container)
         {
             Console.WriteLine("==============================");
-            Console.WriteLine("Available bot commands : start, stop, exit");
+            Console.WriteLine("Available bot commands : start, stop, restart, exit");
             Console.WriteLine("==============================");
 
-            var command = "start";
-            while (true)
+            ILifetimeScope scope = null;
+            try
             {
-                switch (command)
+                IBotMain botMain = null;
+                var command = "start";
+                while (true)
                 {
-                    case "stop":
-                        Console.WriteLine("Bot stopping....");
-                        botMain.Stop();
-                        Console.WriteLine("Bot stopped");
-                        Console.WriteLine("==============================");
-                        break;
-
-                    case "start":
-                        Console.WriteLine("Bot starting....");
-                        botMain.Run();
-                        Console.WriteLine("Bot started");
-                        Console.WriteLine("==============================");
-                        break;
-
-                    case "exit":
-                        return;
-
-                    default:
+                    switch (command)
                     {
-                        Console.WriteLine($"{command} is not a valid command");
-                        break;
-                    }
-                }
+                        case "stop":
+                            Stop(scope, botMain);
+                            break;
 
-                Console.Write("Bot:");
-                command = Console.ReadLine();
+                        case "start":
+                            Start(container, out scope, out botMain);
+                            break;
+
+                        case "restart":
+                            Stop(scope, botMain);
+                            Start(container, out scope, out botMain);
+                            break;
+
+                        case "exit":
+                            return;
+
+                        default:
+                        {
+                            Console.WriteLine($"{command} is not a valid command");
+                            break;
+                        }
+                    }
+
+                    Console.Write("Bot:");
+                    command = Console.ReadLine();
+                }
             }
+            finally
+            {
+                scope?.Dispose();
+            }
+        }
+
+        private static void Stop(ILifetimeScope scope, IBotMain botMain)
+        {
+            Console.WriteLine("Bot stopping....");
+            botMain?.Stop();
+            scope?.Dispose();
+            Console.WriteLine("Bot stopped");
+            Console.WriteLine("==============================");
+        }
+
+        private static void Start(IContainer container, out ILifetimeScope scope, out IBotMain botMain)
+        {
+            Console.WriteLine("Bot starting....");
+            scope = container.BeginLifetimeScope();
+            botMain = scope.Resolve<IBotMain>();
+            botMain.Run();
+            Console.WriteLine("Bot started");
+            Console.WriteLine("==============================");
         }
     }
 }

--- a/src/UnitTests/Core/Events/CommandHandlerTests/CommandReceivedHandlerShould.cs
+++ b/src/UnitTests/Core/Events/CommandHandlerTests/CommandReceivedHandlerShould.cs
@@ -38,7 +38,7 @@ namespace UnitTests.Core.Events.CommandHandlerTests
             var commandUsageTracker = new CommandUsageTracker(new CommandHandlerSettings());
             var chatClients = new List<IChatClient> { new FakeChatClient() };
             var commandMessages = new List<IBotCommand> { fakeCommand };
-            var commandHandler = new CommandHandler(commandUsageTracker, chatClients, commandMessages);
+            var commandHandler = new CommandHandler(commandUsageTracker, chatClients, new CommandList(commandMessages));
             return commandHandler;
         }
     }

--- a/src/UnitTests/Fakes/FakeChatClient.cs
+++ b/src/UnitTests/Fakes/FakeChatClient.cs
@@ -24,7 +24,7 @@ namespace UnitTests.Fakes
             SentMessage = message;
         }
 
-        public List<ChatUser> GetAllChatters()
+        public IList<ChatUser> GetAllChatters()
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
This integrates Autofac to use for a DI container for #15, #56. This is mostly a one to one mapping of the behavior of the original composition root, with the following considerations: 

* Instances are resolved per lifetime scope. This means implementing a restart command is just throwing away the old scope and getting a new one. See `Program.cs` for this. Within the single scope used in each "start" session, they are effectively singletons. 
* The bot needs a `CommandList` custom container class to store all the commands. Autofac supports a [dependency of a collection type](http://autofac.readthedocs.io/en/latest/resolve/relationships.html#enumeration-ienumerable-b-ilist-b-icollection-b) `A(IList<B>)` by injecting in a collection of `B` upon instance resolution. Consequently, a list that we need to add and remove commands from is *not* the same thing as a generated list upon instance creation time, therefore the need to have a custom container. An alternative approach may be to throw away the `ILifetimeScope` upon adding or removing a new command and partially re-initializing the bot. 
* Property injection was used on any `IBotCommand` implementation which directly depends on `IList<IBotCommand>`, because there's a dependency cycle, `BotMain ->CommandHandler -> IBotCommand[] -> HelpCommand -> IBotCommand[]`, which can't be resolved without setting up the instance manually then injecting in the command list. 