### PR TITLE
Removed TimezoneDbSettings from AppSettings

### DIFF
--- a/src/DevChatter.Bot.Web/appsettings.json
+++ b/src/DevChatter.Bot.Web/appsettings.json
@@ -11,10 +11,6 @@
     "TwitchClientId": "secret"
   },
 
-  "TimezoneDbSettings": {
-    "TimezoneDbApiKey": "secret"
-  },
-
   "GoogleCloudSettings": {
     "ApiKey": "secret" 
   },


### PR DESCRIPTION
Removed TimezoneDbSettings from AppSettings as it is not going to be used.

Fixes: #216 