### PR TITLE
Blast Help Text

### DIFF
--- a/src/DevChatter.Bot.Core/Commands/BlastCommand.cs
+++ b/src/DevChatter.Bot.Core/Commands/BlastCommand.cs
@@ -34,7 +34,15 @@ namespace DevChatter.Bot.Core.Commands
             }
             else
             {
-                chatClient.SendMessage(HelpText);
+                var availableBlastTypes = _repository.List(BlastTypeEntityPolicy.All()).Select(bt => bt.Name);
+                if (availableBlastTypes.Count() > 0)
+                {
+                    chatClient.SendMessage(string.Format(HelpText, string.Join(", ", availableBlastTypes)));
+                }
+                else
+                {
+                    chatClient.SendMessage(string.Format(HelpText, "<No configured blast types>"));
+                }
             }
         }
     }

--- a/src/DevChatter.Bot.Web/DefaultData/DefaultCommandData.json
+++ b/src/DevChatter.Bot.Web/DefaultData/DefaultCommandData.json
@@ -30,7 +30,7 @@
     },
     {
       "FullTypeName": "DevChatter.Bot.Core.Commands.BlastCommand",
-      "HelpText": "Use \"!blast [choice]\". Replace [choice] with one of: {choiceText} ",
+      "HelpText": "Use \"!blast [choice]\". Replace [choice] with one of: {0} ",
       "Cooldown": "00:02:00"
     },
     {

--- a/src/UnitTests/Core/Commands/BlastCommandTests/HandleCommandShould.cs
+++ b/src/UnitTests/Core/Commands/BlastCommandTests/HandleCommandShould.cs
@@ -16,11 +16,13 @@ namespace UnitTests.Core.Commands.BlastCommandTests
         [Fact]
         public void SendHelpText_GivenNoArguments()
         {
-            var (chatClient, _, _, blastCommand) = GetTestCommandAndMocks();
+            var (chatClient, repo, _, blastCommand) = GetTestCommandAndMocks();
+            repo.Setup(x => x.List(It.IsAny<DataItemPolicy<BlastTypeEntity>>()))
+                .Returns(new List<BlastTypeEntity>{new BlastTypeEntity{Name = "TestHype"}});
 
             blastCommand.Process(chatClient.Object, new CommandReceivedEventArgs());
 
-            chatClient.Verify(x => x.SendMessage(blastCommand.HelpText));
+            chatClient.Verify(x => x.SendMessage("The TestHype"));
         }
 
         [Fact]
@@ -45,6 +47,9 @@ namespace UnitTests.Core.Commands.BlastCommandTests
         {
             var chatClient = new Mock<IChatClient>();
             var repository = new Mock<IRepository>();
+            repository.Setup(x => x.Single(It.IsAny<CommandPolicy>()))
+                .Returns(new CommandEntity { HelpText = "The {0}" });
+
             var displayNotification = new Mock<IAnimationDisplayNotification>();
             var blastCommand = new BlastCommand(repository.Object, displayNotification.Object);
             return (chatClient, repository, displayNotification, blastCommand);


### PR DESCRIPTION
Closes https://github.com/DevChatter/devchatterbot/issues/263

Blast Types are now read from the DB instead of a variable which is never assigned. If no BlastType exists, the help text changes to show that.